### PR TITLE
Revert to postgres:15-bullseye as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,10 +81,19 @@ RUN mkdir /out /out/lib /out/share /out/share/extension && \
 #
 #########################################################################################
 
-FROM bitnami/postgresql:${PG_MAJOR}-debian-11
+FROM postgres:${PG_MAJOR}-bullseye
 
 LABEL maintainer="Encore - https://encore.dev"
 ARG EXTENSION_DIR
 ARG LIB_DIR
 
-COPY --from=vector-ext /out/ /opt/bitnami/postgresql/
+ENV POSTGIS_MAJOR 3
+ENV POSTGIS_VERSION 3.3.4+dfsg-1.pgdg110+1
+
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION 
+
+COPY --from=vector-ext /out/lib/ ${LIB_DIR}/lib/
+COPY --from=vector-ext /out/share/extension/ ${EXTENSION_DIR}/


### PR DESCRIPTION
We were seeing very slow startup times using the bitnami
base image, and spurious startup failures.
